### PR TITLE
fix: change the time zone from the US to the Brazilian time zone

### DIFF
--- a/app/actions/reports.ts
+++ b/app/actions/reports.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { sql } from "@/lib/db";
+import { formatDateForDisplay, formatTimeForDisplay, sql } from "@/lib/db";
 import crypto from "crypto";
 import { revalidatePath } from "next/cache";
 
@@ -97,23 +97,9 @@ export async function generateReport(
 
       return {
         id: entry.id,
-        date: startTime.toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-        }),
-        startTime: startTime.toLocaleTimeString("en-US", {
-          hour: "numeric",
-          minute: "2-digit",
-          hour12: true,
-        }),
-        endTime: endTime
-          ? endTime.toLocaleTimeString("en-US", {
-              hour: "numeric",
-              minute: "2-digit",
-              hour12: true,
-            })
-          : null,
+        date: formatDateForDisplay(startTime),
+        startTime: formatTimeForDisplay(startTime),
+        endTime: endTime ? formatTimeForDisplay(endTime) : null,
         duration,
         breaks,
         netWork,

--- a/components/edit-time-entry.tsx
+++ b/components/edit-time-entry.tsx
@@ -2,14 +2,8 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { addBreakToTimeEntry, deleteBreak, updateBreak, updateTimeEntry } from "@/app/actions/manual-entries"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Separator } from "@/components/ui/separator"
-import { PlusCircle, Trash2, Edit } from "lucide-react"
-import { updateTimeEntry, addBreakToTimeEntry, updateBreak, deleteBreak } from "@/app/actions/manual-entries"
-import { toast } from "@/components/ui/use-toast"
 import {
   Dialog,
   DialogContent,
@@ -19,6 +13,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/components/ui/use-toast"
+import { Edit, PlusCircle, Trash2 } from "lucide-react"
+import { useState } from "react"
 
 interface EditTimeEntryProps {
   userId: number
@@ -97,8 +97,8 @@ export function EditTimeEntry({
       }
 
       // Create Date objects
-      const startDateTime = new Date(`${date}T${startTime}:00`)
-      const endDateTime = endTime ? new Date(`${date}T${endTime}:00`) : null
+      const startDateTime = new Date(`${date}T${startTime}:00-03:00`)
+      const endDateTime = endTime ? new Date(`${date}T${endTime}:00-03:00`) : null
 
       // Validate start and end times
       if (endDateTime && startDateTime >= endDateTime) {
@@ -123,8 +123,8 @@ export function EditTimeEntry({
         // Skip deleted breaks that are new (not yet in the database)
         if (breakItem.isDeleted && breakItem.isNew) continue
 
-        const breakStartTime = new Date(`${date}T${breakItem.startTime}:00`)
-        const breakEndTime = breakItem.endTime ? new Date(`${date}T${breakItem.endTime}:00`) : null
+        const breakStartTime = new Date(`${date}T${breakItem.startTime}:00-03:00`)
+        const breakEndTime = breakItem.endTime ? new Date(`${date}T${breakItem.endTime}:00-03:00`) : null
 
         // Validate break times
         if (breakEndTime && breakStartTime >= breakEndTime) {

--- a/components/manual-time-entry.tsx
+++ b/components/manual-time-entry.tsx
@@ -2,14 +2,8 @@
 
 import type React from "react"
 
-import { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Separator } from "@/components/ui/separator"
-import { PlusCircle, Trash2, Clock } from "lucide-react"
 import { createManualTimeEntry } from "@/app/actions/manual-entries"
-import { toast } from "@/components/ui/use-toast"
+import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
@@ -19,6 +13,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/components/ui/use-toast"
+import { Clock, PlusCircle, Trash2 } from "lucide-react"
+import { useState } from "react"
 
 interface ManualTimeEntryProps {
   userId: number
@@ -63,9 +63,9 @@ export function ManualTimeEntry({ userId, onSuccess }: ManualTimeEntryProps) {
         return
       }
 
-      // Create Date objects
-      const startDateTime = new Date(`${date}T${startTime}:00`)
-      const endDateTime = endTime ? new Date(`${date}T${endTime}:00`) : null
+      // Create Date objects with Brazil timezone
+      const startDateTime = new Date(`${date}T${startTime}:00-03:00`) // -03:00 is Brazil timezone
+      const endDateTime = endTime ? new Date(`${date}T${endTime}:00-03:00`) : null
 
       // Validate start and end times
       if (endDateTime && startDateTime >= endDateTime) {
@@ -80,8 +80,8 @@ export function ManualTimeEntry({ userId, onSuccess }: ManualTimeEntryProps) {
 
       // Format breaks
       const formattedBreaks = breaks.map((breakItem) => {
-        const breakStartTime = new Date(`${date}T${breakItem.startTime}:00`)
-        const breakEndTime = breakItem.endTime ? new Date(`${date}T${breakItem.endTime}:00`) : null
+        const breakStartTime = new Date(`${date}T${breakItem.startTime}:00-03:00`)
+        const breakEndTime = breakItem.endTime ? new Date(`${date}T${breakItem.endTime}:00-03:00`) : null
 
         // Validate break times
         if (breakEndTime && breakStartTime >= breakEndTime) {

--- a/components/recent-entries.tsx
+++ b/components/recent-entries.tsx
@@ -1,15 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { getRecentTimeEntries } from "@/app/actions/time-entries"
 import { deleteTimeEntry } from "@/app/actions/manual-entries"
-import { formatDuration, calculateDuration } from "@/lib/db"
-import { EditTimeEntry } from "./edit-time-entry"
-import { Trash2 } from "lucide-react"
-import { toast } from "@/components/ui/use-toast"
+import { getRecentTimeEntries } from "@/app/actions/time-entries"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,6 +13,14 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { toast } from "@/components/ui/use-toast"
+import { calculateDuration, formatDateForDisplay, formatDuration, formatTimeForDisplay } from "@/lib/db"
+import { Trash2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import { EditTimeEntry } from "./edit-time-entry"
 
 type Break = {
   id: number
@@ -148,20 +148,12 @@ export function RecentEntries({ userId }: { userId: number }) {
     } else if (date.toDateString() === yesterday.toDateString()) {
       return "Yesterday"
     } else {
-      return date.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
+      return formatDateForDisplay(date)
     }
   }
 
   const formatTime = (dateString: string) => {
-    return new Date(dateString).toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    })
+    return formatTimeForDisplay(new Date(dateString))
   }
 
   if (isLoading && entries.length === 0) {

--- a/components/time-tracker.tsx
+++ b/components/time-tracker.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { endBreak, endTimeEntry, getActiveTimeEntry, startBreak, startTimeEntry } from "@/app/actions/time-entries"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { Play, Coffee, LogOut } from "lucide-react"
-import { startTimeEntry, endTimeEntry, startBreak, endBreak, getActiveTimeEntry } from "@/app/actions/time-entries"
-import { formatDuration } from "@/lib/db"
 import { toast } from "@/components/ui/use-toast"
+import { formatDuration } from "@/lib/db"
+import { Coffee, LogOut, Play } from "lucide-react"
+import { useEffect, useState } from "react"
 import { ManualTimeEntry } from "./manual-time-entry"
 
 export function TimeTracker({ userId }: { userId: number }) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,8 +21,15 @@ let sqlClient: NeonQueryFunction<any, any>
 
 try {
   const dbUrl = getDatabaseUrl()
+  // Set the time zone to Brazil (America/Sao_Paulo) for all database connections
   sqlClient = neon(dbUrl)
-  console.log("Database connection initialized successfully")
+
+  // Initialize the database with the correct time zone
+  sqlClient`SET timezone = 'America/Sao_Paulo'`.catch((err) => {
+    console.error("Failed to set database timezone:", err)
+  })
+
+  console.log("Database connection initialized successfully with Brazil time zone")
 } catch (error) {
   console.error("Failed to initialize database connection:", error)
   // Provide a dummy function that throws an error when used
@@ -44,4 +51,24 @@ export function formatDuration(milliseconds: number): string {
 export function calculateDuration(startTime: Date, endTime: Date | null): number {
   if (!endTime) return 0
   return endTime.getTime() - startTime.getTime()
+}
+
+// Format time with proper 24-hour format for Brazil
+export function formatTimeForDisplay(date: Date): string {
+  return date.toLocaleTimeString("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: "America/Sao_Paulo",
+  })
+}
+
+// Format date for Brazil
+export function formatDateForDisplay(date: Date): string {
+  return date.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: "America/Sao_Paulo",
+  })
 }


### PR DESCRIPTION
This pull request includes several changes to improve date and time handling, along with some import reordering for better code organization. The most important changes include the introduction of new date and time formatting functions, updating timezone handling, and reordering imports for consistency.

### Date and Time Handling Improvements:

* [`app/actions/reports.ts`](diffhunk://#diff-2b82440cf011a70f06b3b335bcbcc7806344359d90ddec1c2353d7e6633dfb19L3-R3): Added `formatDateForDisplay` and `formatTimeForDisplay` functions to format dates and times, and updated the `generateReport` function to use these new functions. [[1]](diffhunk://#diff-2b82440cf011a70f06b3b335bcbcc7806344359d90ddec1c2353d7e6633dfb19L3-R3) [[2]](diffhunk://#diff-2b82440cf011a70f06b3b335bcbcc7806344359d90ddec1c2353d7e6633dfb19L100-R102)
* [`components/edit-time-entry.tsx`](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683L100-R101): Updated the creation of `Date` objects to include the Brazil timezone offset. [[1]](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683L100-R101) [[2]](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683L126-R127)
* [`components/manual-time-entry.tsx`](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fL66-R68): Added Brazil timezone offset to `Date` objects for manual time entries. [[1]](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fL66-R68) [[2]](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fL83-R84)
* [`components/recent-entries.tsx`](diffhunk://#diff-03f5bc4ebe641f8b5ad68c084feb7d9eb5a7d98028111f6f2bf81539a114d530L151-R156): Replaced inline date and time formatting with `formatDateForDisplay` and `formatTimeForDisplay` functions.
* [`lib/db.ts`](diffhunk://#diff-bee0685f8d74755f4a791657dee5a60eed8eb93923f5b0602bdb6339733ab266R24-R32): Set the database timezone to Brazil (America/Sao_Paulo) and added `formatDateForDisplay` and `formatTimeForDisplay` functions. [[1]](diffhunk://#diff-bee0685f8d74755f4a791657dee5a60eed8eb93923f5b0602bdb6339733ab266R24-R32) [[2]](diffhunk://#diff-bee0685f8d74755f4a791657dee5a60eed8eb93923f5b0602bdb6339733ab266R55-R74)

### Import Reordering:

* [`components/edit-time-entry.tsx`](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683L5-L12): Reordered imports for better organization. [[1]](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683L5-L12) [[2]](diffhunk://#diff-f1451b98340254e7b4856931a2d40ec6aa85aa0db26c271b23f5db3d6b704683R16-R21)
* [`components/manual-time-entry.tsx`](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fL5-R6): Reordered imports for better organization. [[1]](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fL5-R6) [[2]](diffhunk://#diff-2a444e704ce80f5d8d25d6011020f429b88874aab90524012bc60ad60d28576fR16-R21)
* [`components/recent-entries.tsx`](diffhunk://#diff-03f5bc4ebe641f8b5ad68c084feb7d9eb5a7d98028111f6f2bf81539a114d530L3-R4): Reordered imports for better organization. [[1]](diffhunk://#diff-03f5bc4ebe641f8b5ad68c084feb7d9eb5a7d98028111f6f2bf81539a114d530L3-R4) [[2]](diffhunk://#diff-03f5bc4ebe641f8b5ad68c084feb7d9eb5a7d98028111f6f2bf81539a114d530R16-R23)
* [`components/time-tracker.tsx`](diffhunk://#diff-c5d81ad20ceb843c8636cdaba6f1224c5c4aa223af50461a79b2d6b8c7e75725L3-R9): Reordered imports for better organization.